### PR TITLE
Bug: Bootstrap record removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ NimBinaries
 *.dSYM
 .vscode/*
 nimbledeps
+*.exe

--- a/archivistdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/archivistdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -454,13 +454,14 @@ proc registerTalkProtocol*(d: Protocol, protocolId: seq[byte],
     ok()
 
 proc replaceNode(d: Protocol, n: Node, forceRemoveBelow = 1.0) =
-  if n.record notin d.bootstrapRecords:
-    d.routingTable.replaceNode(n, forceRemoveBelow)
-  else:
-    # For now we never remove bootstrap nodes. It might make sense to actually
-    # do so and to retry them only in case we drop to a really low amount of
-    # peers in the routing table.
-    debug "Message request to bootstrap node failed", src=d.localNode, dst=n
+  for bn in d.bootstrapRecords:
+    if n.record.data.peerId == bn.data.peerId:
+      # For now we never remove bootstrap nodes. It might make sense to actually
+      # do so and to retry them only in case we drop to a really low amount of
+      # peers in the routing table.
+      debug "Message request to bootstrap node failed", src=d.localNode, dst=n
+      return
+  d.routingTable.replaceNode(n, forceRemoveBelow)
 
 proc sendRequest*[T: SomeMessage](d: Protocol, toNode: Node, m: T,
     reqId: RequestId) =

--- a/tests/discv5/test_discoveryv5.nim
+++ b/tests/discv5/test_discoveryv5.nim
@@ -50,7 +50,14 @@ suite "Discovery v5 Tests":
       pong1 = await discv5_protocol.ping(node1, bootnode.localNode)
       pong2 = await discv5_protocol.ping(node1, node2.localNode)
 
-    check pong1.isOk() and pong2.isOk()
+    check:
+      pong1.isOk()
+      pong2.isOk()
+      node1.addNode(node2.localNode)
+
+    # Seen value is below removal threshold
+    bootnode.localNode.seen = 0.2
+    node2.localNode.seen = 0.2
 
     await bootnode.closeWait()
     await node2.closeWait()
@@ -63,6 +70,8 @@ suite "Discovery v5 Tests":
       n.isSome()
       n.get() == bootnode.localNode
       node1.getNode(node2.localNode.id).isNone()
+      node1.routingTable.contains(bootnode.localNode)
+      not node1.routingTable.contains(node2.localNode)
 
     await node1.closeWait()
 


### PR DESCRIPTION
Found during testing:
Routing tables can become completely empty during period of no connectivity. This means recovery of the network is impossible after connectivity is restored.

The code in `protocol.nim - replaceNode` explicitly says it should not delete the bootstrap nodes for exactly this reason. Yet, bootstrap nodes are deleted.

The issue is located in the usage of the default equality operator for SignedPeerRecords: These include a sequence-number that becomes incremented during the network uptime. This causes equality for the bootstrap records to be false when they shouldn't be.

This fixes that. Also fixes that test that looks like it checks this behavior but actually didn't.
