### PR TITLE
Bug/routing table recovery

### DIFF
--- a/archivistdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/archivistdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -122,7 +122,8 @@ const
   MaxNodesPerMessage = 3 ## Maximum amount of SPRs per individual Nodes message
   RefreshInterval = 5.minutes ## Interval of launching a random query to
   ## refresh the routing table.
-  RoutingTableLowThreshold = 1000 # If we have fewer than 1000 routing table entries, we want more.
+  RoutingTableLowThreshold = 256 # If we have fewer routing table entries, we want more.
+  # (max number of k-buckets)
   RevalidateMin = 5000
   RevalidateMax = 10000 ## Revalidation of a peer is done between min and max milliseconds.
   ## value in milliseconds

--- a/archivistdht/private/eth/p2p/discoveryv5/routing_table.nim
+++ b/archivistdht/private/eth/p2p/discoveryv5/routing_table.nim
@@ -429,13 +429,6 @@ proc addNode*(r: var RoutingTable, n: Node): NodeStatus =
   # When bucket doesn't get split the node is added to the replacement cache
   return r.addReplacement(bucket, n)
 
-proc removeNode*(r: var RoutingTable, n: Node) =
-  ## Remove the node `n` from the routing table.
-  ## No replemennt added, even if there is in replacement cache.
-  let b = r.bucketForNode(n.id)
-  if b.remove(n):
-    ipLimitDec(r, b, n)
-
 proc replaceNode*(r: var RoutingTable, n: Node, forceRemoveBelow = 1.0) =
   ## Replace node `n` with last entry in the replacement cache. If there are
   ## no entries in the replacement cache, node `n` will either be removed

--- a/tests/discv5/test_discoveryv5.nim
+++ b/tests/discv5/test_discoveryv5.nim
@@ -75,7 +75,7 @@ suite "Discovery v5 Tests":
 
     await node1.closeWait()
 
-  test "Node recovery":
+  test "Routing table should recover removed nodes after successful ping":
     let
       node1 = initDiscoveryNode(
         rng, PrivateKey.example(rng), localAddress(20301))

--- a/tests/discv5/test_discoveryv5.nim
+++ b/tests/discv5/test_discoveryv5.nim
@@ -83,13 +83,9 @@ suite "Discovery v5 Tests":
         rng, PrivateKey.example(rng), localAddress(20302))
 
     check:
-      node1.routingTable.len == 0
-      node2.routingTable.len == 0
-
-    check:
       (await node1.ping(node2.localNode)).isOK()
 
-    # Node1 becomes deleted from node2 routing table
+    # node1 becomes deleted from node2 routing table
     # (due to network timeouts for example)
     node2.routingTable.replaceNode(node1.localNode)
 
@@ -104,6 +100,9 @@ suite "Discovery v5 Tests":
     check:
       node1.routingTable.len == 0
       node2.routingTable.len == 1
+
+    await node1.closeWait()
+    await node2.closeWait()
 
   test "Distance check":
     const

--- a/tests/discv5/test_discoveryv5.nim
+++ b/tests/discv5/test_discoveryv5.nim
@@ -75,6 +75,36 @@ suite "Discovery v5 Tests":
 
     await node1.closeWait()
 
+  test "Node recovery":
+    let
+      node1 = initDiscoveryNode(
+        rng, PrivateKey.example(rng), localAddress(20301))
+      node2 = initDiscoveryNode(
+        rng, PrivateKey.example(rng), localAddress(20302))
+
+    check:
+      node1.routingTable.len == 0
+      node2.routingTable.len == 0
+
+    check:
+      (await node1.ping(node2.localNode)).isOK()
+
+    # Node1 becomes deleted from node2 routing table
+    # (due to network timeouts for example)
+    node2.routingTable.replaceNode(node1.localNode)
+
+    check:
+      node1.routingTable.len == 0
+      node2.routingTable.len == 0
+
+    # connectivity is restored and node1 pings node2 again
+    check:
+      (await node1.ping(node2.localNode)).isOK()
+
+    check:
+      node1.routingTable.len == 0
+      node2.routingTable.len == 1
+
   test "Distance check":
     const
       targetId = "0x0000"


### PR DESCRIPTION
Nodes after being removed from the routing table, would never be recovered. This is because the only path to add a node to the routing table was as a result of a transport-layer handshake. This only occurs if the keys of the node are not known. If a node becomes disconnected, but attempts to reconnect before the keys are pushed out of the transport-layer cache, it would never be re-added to the routing table.

This PR fixes that by introducing a flow by which a node can be added back, if the routing table size is below a threshold.
